### PR TITLE
Changed the zip dependency from 'unzip' to 'node-unzip-2'

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ let TaskManager = require('./libs/TaskManager');
 let Task = require('./libs/Task');
 let odmOptions = require('./libs/odmOptions');
 let Directories = require('./libs/Directories');
-let unzip = require('unzip');
+let unzip = require('node-unzip-2');
 
 // zip files
 let request = require('request');

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "morgan": "^1.7.0",
     "multer": "^1.1.0",
     "node-schedule": "^1.1.1",
+    "node-unzip-2": "^0.2.7",
     "node-uuid": "^1.4.7",
     "request": "^2.81.0",
     "rimraf": "^2.5.3",
     "swagger-jsdoc": "^1.3.1",
     "tree-kill": "^1.1.0",
-    "unzip": "^0.1.11",
     "winston": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I've noticed that node-odm will throw an error for certain zip-urls, like this one: 

https://firebasestorage.googleapis.com/v0/b/friendly-pix-776bf.appspot.com/o/LbD76QM7duhWtxaZbjTGnje4E6n1%2Fzips%2F1529195220007%2Fmyzipfile.zip?alt=media&token=1190c978-3fd0-4304-a07f-89c1e59e28a1 

The error that gets returned says "invalid stored block lengths." I was able to get around this by upgrading the "unzip" dependency to "node-unzip-2." The underlying issue is discussed here: https://github.com/EvanOxfeld/node-unzip/issues/40