### PR TITLE
Generate orthophoto MBTiles during post-processing

### DIFF
--- a/scripts/postprocess.sh
+++ b/scripts/postprocess.sh
@@ -59,6 +59,21 @@ else
 	echo "gdal2tiles.py is not installed, will skip tiling"
 fi
 
+# Generate MBTiles
+if hash gdal_translate 2>/dev/null; then
+	orthophoto_path="odm_orthophoto/odm_orthophoto.tif"
+	orthophoto_mbtiles_path="odm_orthophoto/odm_orthophoto.mbtiles"
+
+	if [ -e "$orthophoto_path" ]; then
+		gdal_translate $orthophoto_path $orthophoto_mbtiles_path -of MBTILES
+		gdaladdo -r bilinear $orthophoto_mbtiles_path 2 4 8 16 32 64 128 256 512 1024 2048 4096 8192 16384
+	else
+		echo "No orthophoto found at $orthophoto_path: will skip MBTiles generation"
+	fi
+else
+	echo "gdal_translate is not installed, will skip MBTiles generation"
+fi
+
 # Generate Potree point cloud (if PotreeConverter is available)
 if hash PotreeConverter 2>/dev/null; then
 	potree_input_path=""


### PR DESCRIPTION
Questionable functionality given the equivalence between a GeoTIFF with overviews and an MBTiles archive, although MBTiles are useful for sharing data with apps that are aware of MBTiles but not GeoTIFFs (e.g. OpenMapKit).

Context: https://github.com/posm/posm-build/pull/114